### PR TITLE
update to use rubytter 1.5.x:

### DIFF
--- a/dumptter
+++ b/dumptter
@@ -147,6 +147,7 @@ else
 end
 
 class Status < ActiveRecord::Base
+  scope :newest, -> { order("status_at desc") }
 end
 
 consumer = OAuth::Consumer.new(
@@ -163,7 +164,7 @@ token = OAuth::AccessToken.new(
 
 rubytter = OAuthRubytter.new(token)
 
-latest_status = Status.find(:first, :order=>"status_at DESC")
+latest_status = Status.newest.first
 if latest_status.nil?
   mode = 'init'
   print "Collecting your all tweets (up to 3200, limited in API).\n"

--- a/dumptter
+++ b/dumptter
@@ -82,7 +82,7 @@ else
   consumer = OAuth::Consumer.new(
                                  consumer_key,
                                  consumer_secret,
-                                 :site => "http://api.twitter.com"
+                                 :site => "https://api.twitter.com"
                                  )
   request_token = consumer.get_request_token
   print "Please access and authorize the request from dumptter.\n"
@@ -153,7 +153,7 @@ end
 consumer = OAuth::Consumer.new(
                                twitter_consumer_key,
                                twitter_consumer_secret,
-                               :site => 'http://api.twitter.com'
+                               :site => 'https://api.twitter.com'
                                )
 
 token = OAuth::AccessToken.new(

--- a/dumptter
+++ b/dumptter
@@ -176,9 +176,9 @@ loop = true
 page = 1
 while loop == true do
   if mode == 'init'
-    timeline = rubytter.user_timeline(nil, :count => 200, :page => page)
+    timeline = rubytter.user_timeline(:count => 200, :page => page)
   else
-    timeline = rubytter.user_timeline(nil, :count => 200, :since_id => latest_status.status_id, :page => page)
+    timeline = rubytter.user_timeline(:count => 200, :since_id => latest_status.status_id, :page => page)
   end
   if timeline.size < 200
     loop = false


### PR DESCRIPTION
API変更の影響でしょうか、6月頃からdumptterでの保存がうまくいかなくなっていたようなので修正してみました。
rubytterは1.5.1に更新後に試しています。rubytter 1.5.xのAPI 1.1対応により他にも影響があるのかもしれませんが、今のところ自分は遭遇していないので未確認です。
